### PR TITLE
BW-1266 Make UI proxy aware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN set -x \
   && cd terra-batch-analysis-ui \
   && git checkout main \
   && npm install \
-  && npm run build
+  && PUBLIC_URL="." npm run build # to get relative URLs so that it can be load up in proxied environment
 
 FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:stable-alpine
 COPY --from=0 /terra-batch-analysis-ui/build /usr/share/nginx/html


### PR DESCRIPTION
A new image containing this change has been pushed to GCR: [hello-world-ui-3](https://console.cloud.google.com/gcr/images/broad-dsp-gcr-public/us/terra-batch-analysis-ui?project=broad-dsp-gcr-public)

I tested it by creating Cromwell app in Dev environment and then upgrading the helm charts with the reverse proxy changes along with change that [updates the UI image to hello-world-ui-3](https://github.com/broadinstitute/cromwhelm/pull/36).

UI deployment with latest docker image:
![Screen Shot 2022-06-10 at 2 10 30 PM](https://user-images.githubusercontent.com/16748522/173125813-4d40d2e9-187f-4544-ae58-ce9e7c2b05a1.png)

UI now loads at `https://leonardo.dsde-dev.broadinstitute.org/proxy/google/v1/apps/terra-dev-e64f6eae/terra-app-7312934b-752c-4a89-8812-82fe9f9d1536/cromwell-service/batch-analysis-ui/`

![Screen Shot 2022-06-10 at 2 11 18 PM](https://user-images.githubusercontent.com/16748522/173125894-caebb5be-445f-4e8d-9e82-432cc89e6ad7.png)



Closes https://broadworkbench.atlassian.net/browse/BW-1266