### PR TITLE
BW-1245: CBAS status element bootstrap

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,3 +1,3 @@
 {
-  "key" : "value"
+  "cbasUrlRoot" : "http://localhost:8080"
 }

--- a/src/components/HelloWorld.js
+++ b/src/components/HelloWorld.js
@@ -1,4 +1,4 @@
-import { a, div, h2 } from 'react-hyperscript-helpers'
+import { a, div, h2, p } from 'react-hyperscript-helpers'
 import headerLeftHexes from 'src/images/header-left-hexes.svg'
 import headerRightHexes from 'src/images/header-right-hexes.svg'
 import colors from 'src/libs/colors'
@@ -16,7 +16,7 @@ const styles = {
   }
 }
 
-export const HelloWorld = () => {
+export const HelloWorld = ( { cbasStatus: { ok: cbasOk } } ) => {
   return div({}, [
     div({
       role: 'banner',
@@ -50,6 +50,9 @@ export const HelloWorld = () => {
     ]),
     div({ style: { margin: '1rem' } }, [
       h2(['Hello World!'])
+    ]),
+    div({}, [
+      p(['CBAS Status OK: ', JSON.stringify(cbasOk)])
     ])
   ])
 }

--- a/src/components/HelloWorld.js
+++ b/src/components/HelloWorld.js
@@ -16,7 +16,7 @@ const styles = {
   }
 }
 
-export const HelloWorld = ( { cbasStatus: { ok: cbasOk = false} = {} } ) => {
+export const HelloWorld = ({ cbasStatus: { ok: cbasOk = false } = {} }) => {
   return div({}, [
     div({
       role: 'banner',

--- a/src/components/HelloWorld.js
+++ b/src/components/HelloWorld.js
@@ -16,7 +16,7 @@ const styles = {
   }
 }
 
-export const HelloWorld = ( { cbasStatus: { ok: cbasOk } } ) => {
+export const HelloWorld = ( { cbasStatus: { ok: cbasOk = false} = {} } ) => {
   return div({}, [
     div({
       role: 'banner',

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,8 @@
+import { loadedConfigStore } from 'src/configStore'
+
 const loadApp = async () => {
+  const res = await fetch(`${process.env.PUBLIC_URL}/config.json`)
+  loadedConfigStore.current = await res.json()
 
   import('src/appLoader')
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { loadedConfigStore } from 'src/configStore'
 
+
 const loadApp = async () => {
   const res = await fetch(`${process.env.PUBLIC_URL}/config.json`)
   loadedConfigStore.current = await res.json()

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1,15 +1,7 @@
-// import { getDefaultProperties } from '@databiosphere/bard-client'
 import _ from 'lodash/fp'
-// import * as qs from 'qs'
-// import { getDisplayName, tools } from 'src/components/notebook-utils'
-// import { version } from 'src/data/machines'
-// import { ensureAuthSettled, getUser } from 'src/libs/auth'
 import { getConfig } from 'src/libs/config'
-// import { withErrorIgnoring } from 'src/libs/error'
-// import * as Nav from 'src/libs/nav'
-import { ajaxOverridesStore, authStore, knownBucketRequesterPaysStatuses, requesterPaysProjectStore, workspaceStore } from 'src/libs/state'
+import { ajaxOverridesStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
-// import { v4 as uuid } from 'uuid'
 
 // Allows use of ajaxOverrideStore to stub responses for testing
 const withInstrumentation = wrappedFetch => (...args) => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1,0 +1,60 @@
+// import { getDefaultProperties } from '@databiosphere/bard-client'
+import _ from 'lodash/fp'
+// import * as qs from 'qs'
+// import { getDisplayName, tools } from 'src/components/notebook-utils'
+// import { version } from 'src/data/machines'
+// import { ensureAuthSettled, getUser } from 'src/libs/auth'
+import { getConfig } from 'src/libs/config'
+// import { withErrorIgnoring } from 'src/libs/error'
+// import * as Nav from 'src/libs/nav'
+import { ajaxOverridesStore, authStore, knownBucketRequesterPaysStatuses, requesterPaysProjectStore, workspaceStore } from 'src/libs/state'
+import * as Utils from 'src/libs/utils'
+// import { v4 as uuid } from 'uuid'
+
+// Allows use of ajaxOverrideStore to stub responses for testing
+const withInstrumentation = wrappedFetch => (...args) => {
+  return _.flow(
+    ..._.map('fn', _.filter(({ filter }) => {
+      const [url, { method = 'GET' } = {}] = args
+      return _.isFunction(filter) ? filter(...args) : url.match(filter.url) && (!filter.method || filter.method === method)
+    }, ajaxOverridesStore.get()))
+  )(wrappedFetch)(...args)
+}
+
+// Ignores cancellation error when request is cancelled
+const withCancellation = wrappedFetch => async (...args) => {
+  try {
+    return await wrappedFetch(...args)
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      return Utils.abandonedPromise()
+    } else {
+      throw error
+    }
+  }
+}
+
+// Converts non-200 responses to exceptions
+const withErrorRejection = wrappedFetch => async (...args) => {
+  const res = await wrappedFetch(...args)
+  if (res.ok) {
+    return res
+  } else {
+    throw res
+  }
+}
+
+export const fetchOk = _.flow(withInstrumentation, withCancellation, withErrorRejection)(fetch)
+
+const Cbas = signal => ({
+  status: async () => {
+    const res = await fetchOk(`${getConfig().cbasUrlRoot}/status`, { signal })
+    return res.json()
+  }
+})
+
+export const Ajax = signal => {
+  return {
+    Cbas: Cbas(signal)
+  }
+}

--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -19,7 +19,7 @@ const forceSetItem = (storage, key, value) => {
         console.error('Could not write to storage, and no entries to delete')
         return
       }
-      const [chosenKey] = _.head(_.sortBy(([k, v]) => {
+      const [chosenKey] = _.head(_.sortBy(([_, v]) => {
         const data = maybeParseJSON(v)
         return data && _.isInteger(data.timestamp) ? data.timestamp : -Infinity
       }, candidates))

--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -1,0 +1,120 @@
+import _ from 'lodash/fp'
+import { maybeParseJSON, subscribable } from 'src/libs/utils'
+
+
+/**
+ * This library provides a higher level interface on top of localStorage and sessionStorage.
+ * Values must be JSON-serializable. The 'dynamic' version is preferred if possible, but dynamic
+ * values might be deleted in case of space overflow. For critical data, use the 'static' version.
+ */
+
+const forceSetItem = (storage, key, value) => {
+  while (true) {
+    try {
+      storage.setItem(key, value)
+      return
+    } catch (error) {
+      const candidates = _.filter(([k]) => _.startsWith('dynamic-storage/', k), _.toPairs(storage))
+      if (!candidates.length) {
+        console.error('Could not write to storage, and no entries to delete')
+        return
+      }
+      const [chosenKey] = _.head(_.sortBy(([k, v]) => {
+        const data = maybeParseJSON(v)
+        return data && _.isInteger(data.timestamp) ? data.timestamp : -Infinity
+      }, candidates))
+      storage.removeItem(chosenKey)
+    }
+  }
+}
+
+export const getStatic = (storage, key) => {
+  return maybeParseJSON(storage.getItem(key))
+}
+
+/**
+ * Sets a key/value in browser storage, or removes the key from storage if `value` is undefined.
+ *
+ * Static storage will not be automatically deleted in the case of space overflow. If your storage usage
+ * is transient (for example, navigating between routes and preserving data where the loss of it is not
+ * critical), instead use `setDynamic`.
+ *
+ * See also `staticStorageSlot`, which can be passed to the `useStore` hook function.
+ *
+ * @param storage either one of these `window` properties: `localStorage` or `sessionStorage`
+ * @param key the key for storing the value
+ * @param value the new JSON-serializable value to be stored, or `undefined` to remove the key.
+ */
+export const setStatic = (storage, key, value) => {
+  if (value === undefined) {
+    storage.removeItem(key)
+  } else {
+    forceSetItem(storage, key, JSON.stringify(value))
+  }
+}
+
+export const listenStatic = (storage, key, fn) => {
+  window.addEventListener('storage', e => {
+    if (e.storageArea === storage && e.key === key) {
+      fn(maybeParseJSON(e.newValue))
+    }
+  })
+}
+
+export const getDynamic = (storage, key) => {
+  const storageKey = `dynamic-storage/${key}`
+  const data = maybeParseJSON(storage.getItem(storageKey))
+  return data?.value
+}
+
+/**
+ * Sets a key/value in browser storage, or removes the key from storage if `value` is undefined.
+ *
+ * Dynamic storage will be automatically deleted in the case of space overflow, deleting oldest stored
+ * data first. If your storage usage is not transient, instead use `setStatic`.
+ *
+ * @param storage either one of these `window` properties: `localStorage` or `sessionStorage`
+ * @param key the key for storing the value. Note that it will be prefixed by a value to allow separating
+ * static from dynamic storage.
+ * @param value the new JSON-serializable value to be stored, or `undefined` to remove the key
+ */
+export const setDynamic = (storage, key, value) => {
+  const storageKey = `dynamic-storage/${key}`
+  if (value === undefined) {
+    storage.removeItem(storageKey)
+  } else {
+    forceSetItem(storage, storageKey, JSON.stringify({ timestamp: Date.now(), value }))
+  }
+}
+
+export const listenDynamic = (storage, key, fn) => {
+  const storageKey = `dynamic-storage/${key}`
+  window.addEventListener('storage', e => {
+    if (e.storageArea === storage && e.key === storageKey) {
+      const data = maybeParseJSON(e.newValue)
+      fn(data?.value)
+    }
+  })
+}
+
+/**
+ * Implements the Store interface, and can be passed to useStore.
+ *
+ * Note that this method will use static storage, meaning that it will not
+ * automatically be deleted in the case of space overflow. If the data you are using
+ * is transient, consider using `setDynamic` instead.
+ *
+ * @param storage either one of these `window` properties: `localStorage` or `sessionStorage`
+ * @param key the key for storing the value
+ * @returns stateful object that manages the given storage location
+ */
+export const staticStorageSlot = (storage, key) => {
+  const { subscribe, next } = subscribable()
+  const get = () => getStatic(storage, key)
+  const set = newValue => {
+    setStatic(storage, key, newValue)
+    next(newValue)
+  }
+  listenStatic(storage, key, next)
+  return { subscribe, get, set, update: fn => set(fn(get())) }
+}

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -1,0 +1,9 @@
+import _ from 'lodash/fp'
+import { loadedConfigStore } from 'src/configStore'
+import { configOverridesStore } from 'src/libs/state'
+
+
+export const getConfig = () => {
+  console.assert(loadedConfigStore.current, 'Called getConfig before initialization')
+  return _.merge(loadedConfigStore.current, configOverridesStore.get())
+}

--- a/src/libs/react-utils.js
+++ b/src/libs/react-utils.js
@@ -1,0 +1,179 @@
+import _ from 'lodash/fp'
+import { forwardRef, memo, useEffect, useRef, useState } from 'react'
+import { h } from 'react-hyperscript-helpers'
+import { delay } from 'src/libs/utils'
+
+
+/**
+ * Performs the given effect, but only on component mount.
+ * React's hooks eslint plugin flags [] because it's a common mistake. However, sometimes this is
+ * exactly the right thing to do. This function makes the intention clear and avoids the lint error.
+ */
+export const useOnMount = fn => {
+  useEffect(fn, []) // eslint-disable-line react-hooks/exhaustive-deps
+}
+
+export const usePrevious = value => {
+  const ref = useRef()
+
+  useEffect(() => {
+    ref.current = value
+  })
+
+  return ref.current
+}
+
+/**
+ * Given a value that changes over time, returns a getter function that reads the current value.
+ * Useful for asynchronous processes that need to read the current value of e.g. props or state.
+ */
+export const useGetter = value => {
+  const ref = useRef()
+  ref.current = value
+  return () => ref.current
+}
+
+/**
+ * Calls the provided function to produce and return a value tied to this component instance.
+ * The initializer function is only called once for each component instance, on first render.
+ */
+export const useInstance = fn => {
+  const ref = useRef()
+  if (!ref.current) {
+    ref.current = fn()
+  }
+  return ref.current
+}
+
+export const useUniqueId = () => {
+  return useInstance(() => _.uniqueId('unique-id-'))
+}
+
+export const useCancelable = () => {
+  const [controller, setController] = useState(new window.AbortController())
+
+  // Abort it automatically in the destructor
+  useEffect(() => {
+    return () => controller.abort()
+  }, [controller])
+
+  return {
+    signal: controller.signal,
+    abort: () => {
+      controller.abort()
+      setController(new window.AbortController())
+    }
+  }
+}
+
+export const useCancellation = () => {
+  const controller = useRef()
+  useOnMount(() => {
+    const instance = controller.current
+    return () => instance.abort()
+  })
+  if (!controller.current) {
+    controller.current = new window.AbortController()
+  }
+  return controller.current.signal
+}
+
+export const withDisplayName = _.curry((name, WrappedComponent) => {
+  WrappedComponent.displayName = name
+  return WrappedComponent
+})
+
+export const forwardRefWithName = _.curry((name, WrappedComponent) => {
+  return withDisplayName(name, forwardRef(WrappedComponent))
+})
+
+export const memoWithName = _.curry((name, WrappedComponent) => {
+  return withDisplayName(name, memo(WrappedComponent))
+})
+
+export const withCancellationSignal = WrappedComponent => {
+  return withDisplayName('withCancellationSignal', props => {
+    const signal = useCancellation()
+    return h(WrappedComponent, { ...props, signal })
+  })
+}
+
+export const usePollingEffect = (effectFn, { ms, leading }) => {
+  const signal = useCancellation()
+
+  useOnMount(() => {
+    const poll = async () => {
+      leading && await effectFn()
+      while (!signal.aborted) {
+        await delay(ms)
+        !signal.aborted && await effectFn()
+      }
+    }
+    poll()
+  })
+}
+
+export const useCurrentTime = (initialDelay = 250) => {
+  const [currentTime, setCurrentTime] = useState(Date.now())
+  const signal = useCancellation()
+  const delayRef = useRef(initialDelay)
+  useOnMount(() => {
+    const poll = async () => {
+      while (!signal.aborted) {
+        await delay(delayRef.current)
+        !signal.aborted && setCurrentTime(Date.now())
+      }
+    }
+    poll()
+  })
+  return [currentTime, delay => { delayRef.current = delay }]
+}
+
+/**
+ * Hook that returns the value of a given store. When the store changes, the component will re-render
+ */
+export const useStore = theStore => {
+  const [value, setValue] = useState(theStore.get())
+  useEffect(() => {
+    return theStore.subscribe(v => setValue(v)).unsubscribe
+  }, [theStore, setValue])
+  return value
+}
+
+/**
+ * Asserts that a component has an accessible label, and alerts the developer how to fix it if it doesn't.
+ *
+ * @param componentName The name of the component, which will be printed to the console if there's an alert.
+ * @param [allowLabelledBy] If true (default), the component can have an aria-labelledby linked to another element. Set to false to only allow aria-label.
+ * @param [allowId] If true, the component can have an id linked to a label using htmlFor. This is true for form elements.
+ * @param [allowTooltip] If true, the component can have a tooltip which will be used if needed as the label.
+ * @param [allowContent] If true, the component can used nested textual content as its label, as long as it's not a single unlabelled icon
+ * @param [ariaLabel] Optional: The label provided to the component
+ * @param [ariaLabelledBy] Optional: The ID of the label provided to the component
+ * @param [id]: Optional: The ID of the component if allowId is true
+ * @param [tooltip] Optional: The tooltip provided to the component if allowTooltip is true
+ */
+export const useLabelAssert = (componentName, {
+  allowLabelledBy = true, allowId = false, allowTooltip = false, allowContent = false,
+  'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, id, tooltip
+}) => {
+  const printed = useRef(false)
+
+  if (!printed.current) {
+    // Ensure that the properties contain a label
+    if (!(ariaLabel ||
+      (allowLabelledBy && ariaLabelledBy) ||
+      (allowId && id) || (allowTooltip && tooltip)
+    )) {
+      printed.current = true
+
+      console.warn(`For accessibility, ${componentName} needs a label. Resolve this by doing any of the following: ${allowContent ? `
+  * add a child component with textual content or a label
+  * if the child is an icon, add a label to it` : ''}${allowTooltip ? `
+  * add a tooltip property to this component, which will also be used as the aria-label` : ''}
+  * add an aria-label property to this component${allowLabelledBy ? `
+  * add an aria-labelledby property referencing the id of another component containing the label` : ''}${allowId ? `
+  * create a label component and point its htmlFor property to this component's id` : ''}`)
+    }
+  }
+}

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -1,0 +1,19 @@
+import { staticStorageSlot } from 'src/libs/browser-storage'
+import * as Utils from 'src/libs/utils'
+
+
+/*
+ * Modifies ajax responses for testing purposes.
+ * Can be set to an array of objects of the form { fn, filter }.
+ * The fn should be a fetch wrapper (oldFetch => newFetch) that modifies the request process. (See ajaxOverrideUtils)
+ * If present, filter should be a RegExp that is matched against the url to target specific requests.
+ */
+export const ajaxOverridesStore = Utils.atom()
+window.ajaxOverridesStore = ajaxOverridesStore
+
+/*
+ * Modifies config settings for testing purposes.
+ * Can be set to an object which will be merged with the loaded config object.
+ */
+export const configOverridesStore = staticStorageSlot(sessionStorage, 'config-overrides')
+window.configOverridesStore = configOverridesStore

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -1,0 +1,62 @@
+// import { isToday, isYesterday } from 'date-fns'
+// import { differenceInCalendarMonths } from 'date-fns/fp'
+// import _ from 'lodash/fp'
+// import * as qs from 'qs'
+// import { div, span } from 'react-hyperscript-helpers'
+// import { v4 as uuid } from 'uuid'
+
+import _ from 'lodash/fp'
+
+
+export const subscribable = () => {
+  let subscribers = []
+  return {
+    subscribe: fn => {
+      subscribers = append(fn, subscribers)
+      return {
+        unsubscribe: () => {
+          subscribers = _.without([fn], subscribers)
+        }
+      }
+    },
+    next: (...args) => {
+      _.forEach(fn => fn(...args), subscribers)
+    }
+  }
+}
+
+/**
+ * A simple state container inspired by clojure atoms. Method names were chosen based on similarity
+ * to lodash and Immutable. (deref => get, reset! => set, swap! => update, reset to go back to initial value)
+ * Implements the Store interface
+ */
+export const atom = initialValue => {
+  let value = initialValue
+  const { subscribe, next } = subscribable()
+  const get = () => value
+  const set = newValue => {
+    const oldValue = value
+    value = newValue
+    next(newValue, oldValue)
+  }
+  return { subscribe, get, set, update: fn => set(fn(get())), reset: () => set(initialValue) }
+}
+
+// Returns a promise that will never resolve or reject. Useful for cancelling async flows.
+export const abandonedPromise = () => {
+  return new Promise(() => {})
+}
+
+export const delay = ms => {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export const append = _.curry((value, arr) => _.concat(arr, [value]))
+
+export const maybeParseJSON = maybeJSONString => {
+  try {
+    return JSON.parse(maybeJSONString)
+  } catch {
+    return undefined
+  }
+}

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,9 +1,28 @@
+import _ from 'lodash/fp'
+import { useState } from 'react'
 import { h } from 'react-hyperscript-helpers'
 import { HelloWorld } from 'src/components/HelloWorld'
+import { Ajax } from 'src/libs/ajax'
+import { useCancellation, useOnMount } from 'src/libs/react-utils'
 
 
 const Main = () => {
-  return h(HelloWorld)
+
+  const [cbasStatus, setCbasStatus] = useState()
+  const signal = useCancellation()
+
+  useOnMount(() => {
+    const loadCbasStatus = async () => {
+      const cbasStatus = await Ajax(signal).Cbas.status()
+      setCbasStatus(cbasStatus)
+    }
+
+    loadCbasStatus()
+    return () => {
+    }
+  })
+
+  return h(HelloWorld, { cbasStatus })
 }
 
 export default Main

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,4 +1,3 @@
-import _ from 'lodash/fp'
 import { useState } from 'react'
 import { h } from 'react-hyperscript-helpers'
 import { HelloWorld } from 'src/components/HelloWorld'
@@ -7,7 +6,6 @@ import { useCancellation, useOnMount } from 'src/libs/react-utils'
 
 
 const Main = () => {
-
   const [cbasStatus, setCbasStatus] = useState()
   const signal = useCancellation()
 


### PR DESCRIPTION
Lots of copy/paste from terra-ui to bootstrap. 

TODOs:

- [X] I'm not sure it's safe (if cbas isn't running)
  - Confirmed: works great.
- [X] I needed to add a `@CrossOrigin(origins = "http://localhost:3000")` annotation to `getStatus` in [CBAS](https://github.com/DataBiosphere/terra-batch-analysis/blob/main/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java#L26) to allow the cross-origin requests to work. I don't think this would actually be required in the app because all services would be served as subdomains of the same origin... but that would need to be verified.
  - To be completed in [BW-1283](https://broadworkbench.atlassian.net/browse/BW-1283), if necessary.

Example running locally:

![image](https://user-images.githubusercontent.com/13006282/173159549-8d4e9f4f-f918-4fb9-8742-2a7bc1f43b74.png)

Note for reviewers: everything in `/src/libs/*` was copied across sections from the terra-ui files with the same names. It's probably a good idea to make sure I kept the spirit of the files and the copy/paste isn't horrible, but the actual logic is presumably good on account of its status within terra-ui